### PR TITLE
add-httpsreactdev-under-javascript-frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
+# AIggregator
 
+## Table of Contents
+
+<!-- CATEGORY ANCHORS START -->
+### Categories
+- [JavaScript Frameworks](#javascript-frameworks)
+<!-- CATEGORY ANCHORS END -->
+
+### JavaScript Frameworks
+- [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.


### PR DESCRIPTION
This PR adds the tool [https://react.dev](https://react.dev) under category **JavaScript Frameworks** with summary: React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.