### PR TITLE
add-httpsa2a-protocolorg-under-ai-communication-protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 
 <!-- CATEGORY ANCHORS START -->
 ### Categories
+- [AI Communication Protocols](#ai-communication-protocols)
 - [JavaScript Frameworks](#javascript-frameworks)
 <!-- CATEGORY ANCHORS END -->
+
+### AI Communication Protocols
+- [Agent2Agent (A2A) Protocol](https://a2a-protocol.org): The Agent2Agent (A2A) Protocol is an open standard facilitating seamless communication and collaboration among AI agents across diverse platforms. It enhances interoperability, supports complex workflows, and ensures secure interactions without sharing proprietary logic, complementing the Model Context Protocol (MCP) for robust agentic applications.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.


### PR DESCRIPTION
This PR adds the tool [https://a2a-protocol.org](https://a2a-protocol.org) under category **AI Communication Protocols** with summary: The Agent2Agent (A2A) Protocol is an open standard facilitating seamless communication and collaboration among AI agents across diverse platforms. It enhances interoperability, supports complex workflows, and ensures secure interactions without sharing proprietary logic, complementing the Model Context Protocol (MCP) for robust agentic applications.