### PR TITLE
add-httpsnextjsorg-under-web-development-frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 <!-- CATEGORY ANCHORS START -->
 ### Categories
 - [JavaScript Frameworks](#javascript-frameworks)
+- [Web Development Frameworks](#web-development-frameworks)
 <!-- CATEGORY ANCHORS END -->
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.
+
+### Web Development Frameworks
+- [Next.js](https://nextjs.org): Next.js by Vercel is a React framework for building high-quality web applications, offering features like server-side rendering, data fetching, advanced routing, and CSS support. It is optimized for performance and developer experience, trusted by major companies, and easily deployable on Vercel's frontend cloud.


### PR DESCRIPTION
This PR adds the tool [https://nextjs.org](https://nextjs.org) under category **Web Development Frameworks** with summary: Next.js by Vercel is a React framework for building high-quality web applications, offering features like server-side rendering, data fetching, advanced routing, and CSS support. It is optimized for performance and developer experience, trusted by major companies, and easily deployable on Vercel's frontend cloud.