### PR TITLE
add-httpsgithubcomvercelnextjs-under-web-development-frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 <!-- CATEGORY ANCHORS START -->
 ### Categories
 - [JavaScript Frameworks](#javascript-frameworks)
+- [Web Development Frameworks](#web-development-frameworks)
 <!-- CATEGORY ANCHORS END -->
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.
+
+### Web Development Frameworks
+- [Next.js](https://github.com/vercel/next.js): Next.js is a React framework for building full-stack web applications, offering fast builds through Rust-based JavaScript tooling. It supports server-side rendering, static site generation, and hybrid applications. The project is open-source, widely used, and encourages community contributions.


### PR DESCRIPTION
This PR adds the tool [https://github.com/vercel/next.js](https://github.com/vercel/next.js) under category **Web Development Frameworks** with summary: Next.js is a React framework for building full-stack web applications, offering fast builds through Rust-based JavaScript tooling. It supports server-side rendering, static site generation, and hybrid applications. The project is open-source, widely used, and encourages community contributions.