### PR TITLE
add-bookscribicom-under-ai-writing-assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@
 <!-- CATEGORY ANCHORS START -->
 ### Categories
 - [AI Platforms](#ai-platforms)
+- [AI Writing Assistants](#ai-writing-assistants)
 - [JavaScript Frameworks](#javascript-frameworks)
 <!-- CATEGORY ANCHORS END -->
 
 ### AI Platforms
 - [i10X](https://i10x.ai/): i10X is an AI marketplace offering access to over 500 specialized AI agents and top models for diverse tasks, including creativity, marketing, design, and productivity. It provides these tools at a competitive subscription rate, ensuring high-quality performance with expert-designed functionalities for various applications.
+
+### AI Writing Assistants
+- [BookScribi](https://bookscribi.com/): BookScribi is an AI-powered platform that generates complete non-fiction and poetry books in minutes, requiring no writing or editing. It supports all languages, delivers books in Amazon KDP-ready formats, and enables easy publishing and scaling, ideal for self-publishing and building a book-based business.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.


### PR DESCRIPTION
This PR adds the BookScribi tool under the AI Writing Assistants category in the README. BookScribi is an AI-powered platform that generates complete non-fiction and poetry books in minutes, supporting multiple languages and easy publishing formats.