### PR TITLE
add-https-vuejs-org-under-web-development-frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # AIggregator
 
 ## Table of Contents
-
-<!-- CATEGORY ANCHORS START -->
-### Categories
 - [AI Platforms](#ai-platforms)
 - [JavaScript Frameworks](#javascript-frameworks)
-<!-- CATEGORY ANCHORS END -->
+- [Web Development Frameworks](#web-development-frameworks)
 
 ### AI Platforms
 - [i10X](https://i10x.ai/): i10X is an AI marketplace offering access to over 500 specialized AI agents and top models for diverse tasks, including creativity, marketing, design, and productivity. It provides these tools at a competitive subscription rate, ensuring high-quality performance with expert-designed functionalities for various applications.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.
+
+### Web Development Frameworks
+- [Vue.js](https://vuejs.org): Vue.js is a versatile, approachable, and performant JavaScript framework designed for building web user interfaces. Providing an extensive ecosystem with intuitive APIs and comprehensive documentation, Vue.js offers features like reactivity and compiler optimization, supporting developers from beginners to advanced levels through guides, tutorials, and community resources.


### PR DESCRIPTION
Adding Vue.js under the Web Development Frameworks category. This update includes a summary of Vue.js and ensures link normalization to prevent duplication.