### PR TITLE
add-https-dropmagic-ai-under-e-commerce-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 ## Table of Contents
 
-<!-- CATEGORY ANCHORS START -->
-### Categories
 - [AI Platforms](#ai-platforms)
 - [JavaScript Frameworks](#javascript-frameworks)
-<!-- CATEGORY ANCHORS END -->
+- [E-commerce Tools](#e-commerce-tools)
 
 ### AI Platforms
 - [i10X](https://i10x.ai/): i10X is an AI marketplace offering access to over 500 specialized AI agents and top models for diverse tasks, including creativity, marketing, design, and productivity. It provides these tools at a competitive subscription rate, ensuring high-quality performance with expert-designed functionalities for various applications.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.
+
+### E-commerce Tools
+- [Dropmagic](https://dropmagic.ai): Dropmagic is an AI tool that generates Shopify ecommerce stores within minutes, offering instant branding, product descriptions, and layouts optimized for mobile and conversions, without design or coding skills. It is cost-effective, multilingual, and supports integration with platforms like AliExpress and Amazon for rapid store launch.


### PR DESCRIPTION
Adds [Dropmagic](https://dropmagic.ai) under E-commerce Tools

Tool summary: Dropmagic is an AI tool that generates Shopify ecommerce stores within minutes, offering instant branding, product descriptions, and layouts optimized for mobile and conversions, without design or coding skills. It is cost-effective, multilingual, and supports integration with platforms like AliExpress and Amazon for rapid store launch.