### PR TITLE
Add Sudowrite to AI Writing Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@
 <!-- CATEGORY ANCHORS START -->
 ### Categories
 - [AI Platforms](#ai-platforms)
+- [AI Writing Assistants](#ai-writing-assistants)
 - [JavaScript Frameworks](#javascript-frameworks)
 <!-- CATEGORY ANCHORS END -->
 
 ### AI Platforms
 - [i10X](https://i10x.ai/): i10X is an AI marketplace offering access to over 500 specialized AI agents and top models for diverse tasks, including creativity, marketing, design, and productivity. It provides these tools at a competitive subscription rate, ensuring high-quality performance with expert-designed functionalities for various applications.
+
+### AI Writing Assistants
+- [Sudowrite](https://sudowrite.com/): Sudowrite is an AI writing assistant designed for fiction writers. It helps generate content, provides creative features like describing and expanding scenes, ensures smooth pacing, and offers feedback. Its tools support writers in crafting original stories, refining text, and exploring plot and character ideas seamlessly.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.


### PR DESCRIPTION
This PR adds the Sudowrite tool under the AI Writing Assistants category. Sudowrite is an AI writing assistant designed for fiction writers, helping them generate content, describing and expanding scenes, ensuring smooth pacing, and providing feedback.