### PR TITLE
Add Botpress to Chatbot Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ### Categories
 - [AI Development Frameworks](#ai-development-frameworks)
 - [AI Platforms](#ai-platforms)
+- [Chatbot Platforms](#chatbot-platforms)
 - [JavaScript Frameworks](#javascript-frameworks)
 <!-- CATEGORY ANCHORS END -->
 
@@ -14,6 +15,9 @@
 
 ### AI Platforms
 - [i10X](https://i10x.ai/): i10X is an AI marketplace offering access to over 500 specialized AI agents and top models for diverse tasks, including creativity, marketing, design, and productivity. It provides these tools at a competitive subscription rate, ensuring high-quality performance with expert-designed functionalities for various applications.
+
+### Chatbot Platforms
+- [Botpress](https://github.com/botpress/botpress): Botpress is an open-source platform for building and deploying GPT/LLM-powered chatbot agents. It offers tools for creating integrations, plugins, and bots using a CLI and SDK, with community contributions encouraged. It supports integration deployment via the Botpress Cloud platform.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.


### PR DESCRIPTION
Adding Botpress to the Chatbot Platforms category as an open-source framework for building GPT/LLM-powered chatbots.