### PR TITLE
Add Vocable AI to Content Marketing Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ### Categories
 - [AI Development Frameworks](#ai-development-frameworks)
 - [AI Platforms](#ai-platforms)
+- [Content Marketing Platforms](#content-marketing-platforms)
 - [JavaScript Frameworks](#javascript-frameworks)
 <!-- CATEGORY ANCHORS END -->
 
@@ -14,6 +15,9 @@
 
 ### AI Platforms
 - [i10X](https://i10x.ai/): i10X is an AI marketplace offering access to over 500 specialized AI agents and top models for diverse tasks, including creativity, marketing, design, and productivity. It provides these tools at a competitive subscription rate, ensuring high-quality performance with expert-designed functionalities for various applications.
+
+### Content Marketing Platforms
+- [Vocable AI](https://vocable.ai/): Vocable AI is a comprehensive content marketing platform that automates the creation, management, and publishing of branded content. It generates content plans, ensures brand voice consistency, and provides multi-AI assistance for refining posts across multiple channels.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.


### PR DESCRIPTION
This PR adds Vocable AI to the Content Marketing Platforms category in the README.